### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -7,15 +7,15 @@
     "export"
   ],
   "description": "Export videos project and prepares downloadable tar archive",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {
     "items": "True",
     "max_parallel_video_downloads": 5,
-	"split_result": false,
-	"split_size": 5
+    "split_result": false,
+    "split_size": 5
   },
   "task_location": "workspace_tasks",
   "isolate": true,

--- a/config.json
+++ b/config.json
@@ -8,7 +8,7 @@
   ],
   "description": "Export videos project and prepares downloadable tar archive",
   "docker_image": "supervisely/import-export:6.73.564",
-  "instance_version": "6.15.40",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
     "export"
   ],
   "description": "Export videos project and prepares downloadable tar archive",
-  "docker_image": "supervisely/import-export:6.73.522",
+  "docker_image": "supervisely/import-export:6.73.564",
   "instance_version": "6.15.40",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.514
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
